### PR TITLE
change SPDX identifier to AGPL-3.0-only

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
   "name": "@imcotton/pkg-fence",
   "version": "0.2.3",
   "description": "tbd",
-  "license": "AGPL-3.0-or-later",
+  "license": "AGPL-3.0-only",
   "imports": {
     "@std/testing": "jsr:@std/testing@^0.225.3",
     "@std/assert": "jsr:@std/assert@^0.226.0"

--- a/tmp-package.json
+++ b/tmp-package.json
@@ -2,7 +2,7 @@
   "name": "pkg-fence",
   "version": "0.0.0-VERSION",
   "description": "tbd",
-  "license": "AGPL-3.0-or-later",
+  "license": "AGPL-3.0-only",
   "repository": {
     "url": "https://github.com/imcotton/pkg-fence.git",
     "type": "git"


### PR DESCRIPTION
For better accuracy, `AGPL-3.0-only` is the one from license selector GUI on GitHub. 